### PR TITLE
fix(cli): auto-populate content metadata for bare file pipeline sources

### DIFF
--- a/cli/src/commands/bootprofile.rs
+++ b/cli/src/commands/bootprofile.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::CString;
 use std::fs;
 use std::future::Future;
@@ -30,7 +30,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tracing::{debug, info};
 
-use super::ArtifactReaderResolver;
+use super::{ArtifactReaderResolver, hydrate_pipeline_file_content};
 
 #[derive(Args)]
 pub struct BootProfileArgs {
@@ -121,9 +121,11 @@ async fn run_create(args: BootProfileCreateArgs) -> Result<()> {
         .with_context(|| format!("parsing boot profile document {}", io_label(&args.input)))?;
     debug!(profile_id = %manifest.id, "bootprofile create parsed manifest");
 
-    let compiled = manifest
+    let mut compiled = manifest
         .compile_dt_overlays(compile_dt_overlay)
         .context("compiling dt_overlays with dtc")?;
+
+    hydrate_profile_file_content(&mut compiled)?;
 
     validate_boot_profile(&compiled).map_err(|err| anyhow!("{err}"))?;
 
@@ -171,6 +173,18 @@ async fn run_create(args: BootProfileCreateArgs) -> Result<()> {
         output = %io_label(&args.output),
         "bootprofile create finished"
     );
+    Ok(())
+}
+
+fn hydrate_profile_file_content(profile: &mut BootProfile) -> Result<()> {
+    let mut cache = HashMap::new();
+    hydrate_pipeline_file_content(profile.rootfs.source_mut(), &mut cache)?;
+    if let Some(kernel) = profile.kernel.as_mut() {
+        hydrate_pipeline_file_content(kernel.artifact_source_mut(), &mut cache)?;
+    }
+    if let Some(dtbs) = profile.dtbs.as_mut() {
+        hydrate_pipeline_file_content(dtbs.artifact_source_mut(), &mut cache)?;
+    }
     Ok(())
 }
 
@@ -1406,6 +1420,7 @@ mod tests {
     use fastboop_core::{
         BootProfileArtifactSource, BootProfileRootfs, BootProfileRootfsFilesystemSource,
     };
+    use gibblox_pipeline::PipelineSourceContent;
     use std::{
         collections::BTreeSet,
         fs,
@@ -1809,6 +1824,81 @@ rootfs:
 
         identities.sort_unstable();
         assert_eq!(identities, sorted);
+    }
+
+    #[test]
+    fn hydrate_profile_file_content_populates_bare_file_sources() {
+        let rootfs_path = temp_path("hydrate-rootfs.img");
+        let kernel_path = temp_path("hydrate-kernel.img");
+        fs::write(&rootfs_path, b"rootfs fixture bytes").expect("write rootfs fixture");
+        fs::write(&kernel_path, b"kernel fixture bytes").expect("write kernel fixture");
+
+        let yaml = format!(
+            "id: local-hydrate\nrootfs:\n  ext4:\n    gpt:\n      index: 1\n      android_sparseimg:\n        file: '{}'\nkernel:\n  path: /vmlinuz\n  fat:\n    file: '{}'\n",
+            rootfs_path.display(),
+            kernel_path.display(),
+        );
+        let manifest: BootProfileManifest =
+            serde_yaml::from_str(&yaml).expect("parse hydrate manifest");
+
+        let mut compiled = manifest
+            .compile_dt_overlays::<core::convert::Infallible, _>(|_| unreachable!())
+            .expect("compile profile");
+
+        assert!(
+            validate_boot_profile(&compiled).is_err(),
+            "bare file sources should fail validation before hydration"
+        );
+
+        hydrate_profile_file_content(&mut compiled).expect("hydrate file content");
+        validate_boot_profile(&compiled).expect("validation after hydration");
+
+        fn rootfs_file_content(profile: &BootProfile) -> PipelineSourceContent {
+            match profile.rootfs.source() {
+                BootProfileArtifactSource::Gpt(gpt) => match gpt.gpt.source.as_ref() {
+                    BootProfileArtifactSource::AndroidSparseImg(sparse) => {
+                        match sparse.android_sparseimg.source.as_ref() {
+                            BootProfileArtifactSource::File(file) => file
+                                .content
+                                .as_ref()
+                                .expect("rootfs file content populated")
+                                .clone(),
+                            other => panic!("expected file inner source, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected android_sparseimg inner source, got {other:?}"),
+                },
+                other => panic!("expected gpt root source, got {other:?}"),
+            }
+        }
+
+        let rootfs_content = rootfs_file_content(&compiled);
+        assert!(rootfs_content.digest.starts_with("sha512:"));
+        assert_eq!(
+            rootfs_content.size_bytes,
+            b"rootfs fixture bytes".len() as u64
+        );
+
+        let kernel = compiled.kernel.as_ref().expect("kernel populated");
+        let kernel_content = match kernel.artifact_source() {
+            BootProfileArtifactSource::File(file) => file
+                .content
+                .as_ref()
+                .expect("kernel file content populated"),
+            other => panic!("expected kernel file source, got {other:?}"),
+        };
+        assert!(kernel_content.digest.starts_with("sha512:"));
+        assert_eq!(
+            kernel_content.size_bytes,
+            b"kernel fixture bytes".len() as u64
+        );
+
+        hydrate_profile_file_content(&mut compiled).expect("second hydration is a no-op");
+        let rootfs_content_after = rootfs_file_content(&compiled);
+        assert_eq!(rootfs_content_after.digest, rootfs_content.digest);
+
+        let _ = fs::remove_file(rootfs_path);
+        let _ = fs::remove_file(kernel_path);
     }
 
     const SPARSE_MAGIC: u32 = 0xED26_FF3A;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -923,6 +923,65 @@ fn sha512_file(path: &Path) -> Result<String> {
     Ok(format!("sha512:{:x}", hasher.finalize()))
 }
 
+pub(super) fn hydrate_pipeline_file_content(
+    source: &mut PipelineSource,
+    cache: &mut HashMap<PathBuf, PipelineSourceContent>,
+) -> Result<()> {
+    match source {
+        PipelineSource::File(file) => {
+            if file.content.is_some() {
+                return Ok(());
+            }
+            let path = Path::new(file.file.as_str());
+            let canonical = fs::canonicalize(path)
+                .with_context(|| format!("canonicalize file pipeline source {}", path.display()))?;
+            if let Some(cached) = cache.get(&canonical) {
+                file.content = Some(cached.clone());
+                return Ok(());
+            }
+            let metadata = fs::metadata(&canonical)
+                .with_context(|| format!("stat file pipeline source {}", canonical.display()))?;
+            if !metadata.is_file() {
+                bail!(
+                    "file pipeline source {} is not a regular file",
+                    canonical.display()
+                );
+            }
+            let size_bytes = metadata.len();
+            info!(
+                path = %canonical.display(),
+                size_bytes,
+                "hashing local file pipeline source"
+            );
+            let started = Instant::now();
+            let digest = sha512_file(canonical.as_path())?;
+            let elapsed = started.elapsed();
+            info!(
+                path = %canonical.display(),
+                digest = %digest,
+                size_bytes,
+                elapsed_ms = elapsed.as_millis() as u64,
+                "hydrated file pipeline source content metadata"
+            );
+            let content = PipelineSourceContent { digest, size_bytes };
+            cache.insert(canonical, content.clone());
+            file.content = Some(content);
+            Ok(())
+        }
+        PipelineSource::Http(_) | PipelineSource::Casync(_) => Ok(()),
+        PipelineSource::Xz(source) => hydrate_pipeline_file_content(source.xz.as_mut(), cache),
+        PipelineSource::AndroidSparseImg(source) => {
+            hydrate_pipeline_file_content(source.android_sparseimg.source.as_mut(), cache)
+        }
+        PipelineSource::Mbr(source) => {
+            hydrate_pipeline_file_content(source.mbr.source.as_mut(), cache)
+        }
+        PipelineSource::Gpt(source) => {
+            hydrate_pipeline_file_content(source.gpt.source.as_mut(), cache)
+        }
+    }
+}
+
 fn artifact_source_cache_key(source: &BootProfileArtifactSource) -> Result<String> {
     match source {
         BootProfileArtifactSource::Http(source) => Ok(format!("http:{}", source.http)),

--- a/crates/fastboop-schema/src/lib.rs
+++ b/crates/fastboop-schema/src/lib.rs
@@ -471,6 +471,15 @@ impl BootProfileRootfs {
         }
     }
 
+    pub fn source_mut(&mut self) -> &mut BootProfileArtifactSource {
+        match self {
+            Self::Ostree(source) => source.source_mut(),
+            Self::Erofs(source) => &mut source.erofs,
+            Self::Ext4(source) => &mut source.ext4,
+            Self::Fat(source) => &mut source.fat,
+        }
+    }
+
     pub fn is_ostree(&self) -> bool {
         matches!(self, Self::Ostree(_))
     }
@@ -486,6 +495,10 @@ pub struct BootProfileRootfsOstreeSource {
 impl BootProfileRootfsOstreeSource {
     pub fn source(&self) -> &BootProfileArtifactSource {
         self.ostree.source()
+    }
+
+    pub fn source_mut(&mut self) -> &mut BootProfileArtifactSource {
+        self.ostree.source_mut()
     }
 }
 
@@ -506,6 +519,14 @@ impl BootProfileRootfsFilesystemSource {
             Self::Fat(source) => &source.fat,
         }
     }
+
+    pub fn source_mut(&mut self) -> &mut BootProfileArtifactSource {
+        match self {
+            Self::Erofs(source) => &mut source.erofs,
+            Self::Ext4(source) => &mut source.ext4,
+            Self::Fat(source) => &mut source.fat,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -519,6 +540,10 @@ pub struct BootProfileArtifactPathSource {
 impl BootProfileArtifactPathSource {
     pub fn artifact_source(&self) -> &BootProfileArtifactSource {
         self.source.source()
+    }
+
+    pub fn artifact_source_mut(&mut self) -> &mut BootProfileArtifactSource {
+        self.source.source_mut()
     }
 }
 

--- a/docs/dev/BOOT_PROFILES.md
+++ b/docs/dev/BOOT_PROFILES.md
@@ -86,7 +86,7 @@ extra_cmdline: console=ttyMSM0,115200n8
 - `rootfs` schema supports `erofs`, `ext4`, and `fat`.
 - Stage0 lower-root currently accepts `erofs` and `ext4`; use `fat` for kernel/dtbs source pipelines.
 - Artifact pipeline validation/limits come from `gibblox-pipeline` (`MAX_PIPELINE_DEPTH=16`).
-- Terminal stages (`http`, `casync`, `file`) must include `content` metadata (`digest`, `size_bytes`).
+- Terminal stages (`http`, `casync`, `file`) must include `content` metadata (`digest`, `size_bytes`). `bootprofile create` auto-populates `content` for bare local `file` sources by hashing the referenced path, so hand-authored manifests pointing at `pmbootstrap export` output (or any other local artifact) can omit it.
 - Wrapper stages (`xz`, `android_sparseimg`, `mbr`, `gpt`) may include optional `content` metadata.
 - GPT/MBR selector steps must choose exactly one selector field.
 - `kernel.path` and `dtbs.path` (if present) must be non-empty.


### PR DESCRIPTION
Restores the pmbootstrap export -> bootprofile create loop after gibblox-pipeline rc.19 started requiring content metadata on terminal stages. bootprofile create now hashes referenced local paths at compile time, caching by canonical path so the same artifact referenced from rootfs/kernel/dtbs is only hashed once.