### PR TITLE
fix(web,desktop): use channel DevPros as matching pool

### DIFF
--- a/packages/desktop/src/views/home.rs
+++ b/packages/desktop/src/views/home.rs
@@ -280,7 +280,12 @@ async fn probe_fastboot_devices(
 fn load_profiles_for_channel(
     intake: &crate::StartupChannelIntake,
 ) -> Vec<fastboop_core::DeviceProfile> {
-    let profiles = builtin_profiles().unwrap_or_default();
+    let channel_dev_profiles = &intake.stream_head.dev_profiles;
+    let profiles = if channel_dev_profiles.is_empty() {
+        builtin_profiles().unwrap_or_default()
+    } else {
+        channel_dev_profiles.clone()
+    };
 
     let allowed_by_boot_profiles =
         allowed_boot_profile_device_ids(&intake.stream_head.boot_profiles);

--- a/packages/web/src/views/home.rs
+++ b/packages/web/src/views/home.rs
@@ -688,7 +688,12 @@ fn set_startup_channel_drop_error(
 fn load_profiles_for_channel(
     intake: &crate::StartupChannelIntake,
 ) -> Vec<fastboop_core::DeviceProfile> {
-    let profiles = builtin_profiles().unwrap_or_default();
+    let channel_dev_profiles = &intake.stream_head.dev_profiles;
+    let profiles = if channel_dev_profiles.is_empty() {
+        builtin_profiles().unwrap_or_default()
+    } else {
+        channel_dev_profiles.clone()
+    };
 
     let allowed_by_boot_profiles =
         allowed_boot_profile_device_ids(&intake.stream_head.boot_profiles);


### PR DESCRIPTION
Both frontends only loaded builtin profiles for WebUSB/native filters and probe candidates. Channel-carried DevPros were stashed on the session for post-selection validation but never reached the probe path, so a channel-only DevPro could never match a connected device.

When the channel carries DevPros, use them as the matching pool (replace, not union) before applying BootProfile device narrowing.