### PR TITLE
refactor(cli,desktop,web): stop auto-downgrading bootimg header for appended dtb

### DIFF
--- a/cli/src/commands/boot.rs
+++ b/cli/src/commands/boot.rs
@@ -438,7 +438,6 @@ async fn run_boot_inner(
     );
 
     let mut kernel_image = build.kernel_image;
-    let mut profile = profile;
     if profile
         .boot
         .fastboot_boot
@@ -448,15 +447,6 @@ async fn run_boot_inner(
         .append_dtb()
     {
         kernel_image.extend_from_slice(&build.dtb);
-        let header_version = profile.boot.fastboot_boot.android_bootimg.header_version;
-        if header_version >= 2 {
-            debug!(
-                from = header_version,
-                to = 0,
-                "downgrading android boot header for appended dtb"
-            );
-            profile.boot.fastboot_boot.android_bootimg.header_version = 0;
-        }
     }
 
     let bootimg = build_android_bootimg(

--- a/devprofiles.d/arrow-db410c.yaml
+++ b/devprofiles.d/arrow-db410c.yaml
@@ -16,7 +16,7 @@ probe:
 boot:
   fastboot_boot:
     android_bootimg:
-      header_version: 2
+      header_version: 0
       page_size: 2048
       base: 0x80000000
 

--- a/devprofiles.d/google-sargo.yaml
+++ b/devprofiles.d/google-sargo.yaml
@@ -14,7 +14,7 @@ probe:
 boot:
   fastboot_boot:
     android_bootimg:
-      header_version: 2
+      header_version: 0
       page_size: 4096
       kernel_offset: 0x00008000
 

--- a/devprofiles.d/samsung-gt510.yaml
+++ b/devprofiles.d/samsung-gt510.yaml
@@ -16,7 +16,7 @@ probe:
 boot:
   fastboot_boot:
     android_bootimg:
-      header_version: 2
+      header_version: 0
       page_size: 2048
       base: 0x80000000
 

--- a/packages/desktop/src/views/device_boot.rs
+++ b/packages/desktop/src/views/device_boot.rs
@@ -163,7 +163,7 @@ pub async fn boot_selected_device(
         Some(build.kernel_cmdline_append.as_str()),
     );
     let mut kernel_image = build.kernel_image;
-    let mut profile = session.device.profile.clone();
+    let profile = session.device.profile.clone();
     if profile
         .boot
         .fastboot_boot
@@ -173,10 +173,6 @@ pub async fn boot_selected_device(
         .append_dtb()
     {
         kernel_image.extend_from_slice(&build.dtb);
-        let header_version = profile.boot.fastboot_boot.android_bootimg.header_version;
-        if header_version >= 2 {
-            profile.boot.fastboot_boot.android_bootimg.header_version = 0;
-        }
     }
     let bootimg = build_android_bootimg(
         &profile,

--- a/packages/web/src/views/device_boot.rs
+++ b/packages/web/src/views/device_boot.rs
@@ -367,7 +367,7 @@ pub async fn boot_selected_device(
         Some(build.kernel_cmdline_append.as_str()),
     );
     let mut kernel_image = build.kernel_image;
-    let mut profile = session.device.profile.clone();
+    let profile = session.device.profile.clone();
     if profile
         .boot
         .fastboot_boot
@@ -377,10 +377,6 @@ pub async fn boot_selected_device(
         .append_dtb()
     {
         kernel_image.extend_from_slice(&build.dtb);
-        let header_version = profile.boot.fastboot_boot.android_bootimg.header_version;
-        if header_version >= 2 {
-            profile.boot.fastboot_boot.android_bootimg.header_version = 0;
-        }
     }
     let bootimg = build_android_bootimg(
         &profile,


### PR DESCRIPTION
The CLI/desktop/web boot paths silently rewrote header_version to 0 whenever the profile used an `image.*+dtb` encoding. That conflated "I want an appended DTB" with "my bootloader can't read header-v2", which isn't universal — SDM845-era bootloaders (e.g. shift-axolotl) want a v2 header AND an appended DTB.

Drop the downgrade; let profiles declare the header_version they actually want. Pin the three profiles that were relying on the implicit downgrade (arrow-db410c, google-sargo, samsung-gt510) to header_version: 0 so their emitted image is unchanged.