### PR TITLE
Prefix matching in fastboot probes + shift-axolotl DevPro

### DIFF
--- a/cli/src/commands/devprofile.rs
+++ b/cli/src/commands/devprofile.rs
@@ -266,7 +266,7 @@ mod tests {
         let yaml = r#"
 id: dev-one
 display_name: Dev One
-devicetree_name: oneplus,enchilada
+devicetree_name: qcom/sdm845-shift-axolotl
 match:
   - fastboot:
       vid: 0x18d1
@@ -297,6 +297,42 @@ probe: []
             decoded.r#match[0].fastboot.pid,
             profile.r#match[0].fastboot.pid
         );
+    }
+
+    #[test]
+    fn starts_with_probe_roundtrips() {
+        let yaml = r#"
+id: dev-one
+display_name: Dev One
+devicetree_name: oneplus,enchilada
+match:
+  - fastboot:
+      vid: 0x18d1
+      pid: 0x4ee1
+probe:
+  - fastboot.getvar: serialno
+    starts_with: S6MQ
+boot:
+  fastboot_boot:
+    android_bootimg:
+      header_version: 2
+      page_size: 4096
+      kernel:
+        encoding: image
+stage0: {}
+"#;
+
+        let profile: DeviceProfile = serde_yaml::from_str(yaml).expect("parse device profile");
+        let encoded = encode_dev_profile(&profile).expect("encode device profile");
+        let decoded = decode_dev_profile(&encoded).expect("decode device profile");
+
+        match &decoded.probe[0] {
+            fastboop_core::ProbeStep::FastbootGetvarStartsWith(check) => {
+                assert_eq!(check.name, "serialno");
+                assert_eq!(check.starts_with, "S6MQ");
+            }
+            other => panic!("unexpected probe step: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/fastboop-core/src/fastboot.rs
+++ b/crates/fastboop-core/src/fastboot.rs
@@ -230,12 +230,39 @@ pub async fn probe_profile_with_cache<F: FastbootWire>(
                     name = %check.name,
                     cached = cached,
                     value = %value,
-                    "fastboot getvar"
+                    "fastboot getvar (equals)"
                 );
                 if value != check.equals {
                     return Err(ProbeError::Mismatch {
                         name: check.name.clone(),
                         expected: check.equals.clone(),
+                        actual: value,
+                    });
+                }
+            }
+            ProbeStep::FastbootGetvarStartsWith(check) => {
+                let mut cached = true;
+                let value = if let Some(value) = cache.get(&check.name) {
+                    value.clone()
+                } else {
+                    cached = false;
+                    let value = getvar(fastboot, &check.name)
+                        .await
+                        .map_err(ProbeError::Transport)?;
+                    cache.insert(check.name.clone(), value.clone());
+                    value
+                };
+                debug!(
+                    profile_id = %profile.id,
+                    name = %check.name,
+                    cached = cached,
+                    value = %value,
+                    "fastboot getvar (starts_with)"
+                );
+                if !value.starts_with(&check.starts_with) {
+                    return Err(ProbeError::Mismatch {
+                        name: check.name.clone(),
+                        expected: format!("starts with {}", check.starts_with),
                         actual: value,
                     });
                 }

--- a/crates/fastboop-core/src/prober.rs
+++ b/crates/fastboop-core/src/prober.rs
@@ -119,8 +119,8 @@ mod tests {
     use super::*;
     use crate::devpro::{
         AndroidBootImage, AndroidInitrd, AndroidKernel, Boot, BootLimits, BootPayload,
-        DeviceProfile, FastbootGetvarEq, FastbootMatch, KernelEncoding, MatchRule, ProbeStep,
-        Stage0,
+        DeviceProfile, FastbootGetvarEq, FastbootGetvarStartsWith, FastbootMatch, KernelEncoding,
+        MatchRule, ProbeStep, Stage0,
     };
     use crate::fastboot::{FastbootWire, Response};
     use alloc::collections::BTreeMap;
@@ -360,6 +360,52 @@ mod tests {
         let reports = block_on(probe_candidates(&[profile], &candidates));
         assert_eq!(reports.len(), 1);
         assert!(reports[0].attempts[0].result.is_ok());
+    }
+
+    #[test]
+    fn probe_starts_with_succeeds_when_prefix_matches() {
+        let mut responses = BTreeMap::new();
+        responses.insert("serialno".to_string(), "S6MQ123456".to_string());
+        let candidates = vec![MockCandidate::new(0x1234, 0x5678, responses)];
+
+        let profile = dummy_profile(
+            "test",
+            0x1234,
+            0x5678,
+            vec![ProbeStep::FastbootGetvarStartsWith(
+                FastbootGetvarStartsWith {
+                    name: "serialno".to_string(),
+                    starts_with: "S6MQ".to_string(),
+                },
+            )],
+        );
+
+        let reports = block_on(probe_candidates(&[profile], &candidates));
+        assert_eq!(reports.len(), 1);
+        assert!(reports[0].attempts[0].result.is_ok());
+    }
+
+    #[test]
+    fn probe_starts_with_fails_when_prefix_differs() {
+        let mut responses = BTreeMap::new();
+        responses.insert("serialno".to_string(), "FAJ123456".to_string());
+        let candidates = vec![MockCandidate::new(0x1234, 0x5678, responses)];
+
+        let profile = dummy_profile(
+            "test",
+            0x1234,
+            0x5678,
+            vec![ProbeStep::FastbootGetvarStartsWith(
+                FastbootGetvarStartsWith {
+                    name: "serialno".to_string(),
+                    starts_with: "S6MQ".to_string(),
+                },
+            )],
+        );
+
+        let reports = block_on(probe_candidates(&[profile], &candidates));
+        assert_eq!(reports.len(), 1);
+        assert!(reports[0].attempts[0].result.is_err());
     }
 
     #[test]

--- a/crates/fastboop-schema/src/bin.rs
+++ b/crates/fastboop-schema/src/bin.rs
@@ -11,8 +11,8 @@ use crate::{
     BootProfileDeviceStage0, BootProfileRootfs, BootProfileRootfsErofsSource,
     BootProfileRootfsExt4Source, BootProfileRootfsFatSource, BootProfileRootfsFilesystemSource,
     BootProfileRootfsOstreeSource, BootProfileStage0, DeviceProfile, ExistsFlag, FastbootGetvarEq,
-    FastbootGetvarExists, FastbootGetvarNotEq, FastbootGetvarNotExists, InjectMac, MatchRule,
-    NotExistsFlag, ProbeStep, Stage0,
+    FastbootGetvarExists, FastbootGetvarNotEq, FastbootGetvarNotExists, FastbootGetvarStartsWith,
+    InjectMac, MatchRule, NotExistsFlag, ProbeStep, Stage0,
 };
 
 // v0 wire formats are intentionally unstable while fastboop is unreleased.
@@ -98,6 +98,7 @@ pub struct DeviceProfileBin {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ProbeStepBin {
     FastbootGetvarEq { name: String, equals: String },
+    FastbootGetvarStartsWith { name: String, starts_with: String },
     FastbootGetvarNotEq { name: String, not_equals: String },
     FastbootGetvarExists { name: String },
     FastbootGetvarNotExists { name: String },
@@ -149,6 +150,9 @@ impl From<ProbeStep> for ProbeStepBin {
             ProbeStep::FastbootGetvarEq(FastbootGetvarEq { name, equals }) => {
                 ProbeStepBin::FastbootGetvarEq { name, equals }
             }
+            ProbeStep::FastbootGetvarStartsWith(FastbootGetvarStartsWith { name, starts_with }) => {
+                ProbeStepBin::FastbootGetvarStartsWith { name, starts_with }
+            }
             ProbeStep::FastbootGetvarNotEq(FastbootGetvarNotEq { name, not_equals }) => {
                 ProbeStepBin::FastbootGetvarNotEq { name, not_equals }
             }
@@ -167,6 +171,9 @@ impl From<ProbeStepBin> for ProbeStep {
         match step {
             ProbeStepBin::FastbootGetvarEq { name, equals } => {
                 ProbeStep::FastbootGetvarEq(FastbootGetvarEq { name, equals })
+            }
+            ProbeStepBin::FastbootGetvarStartsWith { name, starts_with } => {
+                ProbeStep::FastbootGetvarStartsWith(FastbootGetvarStartsWith { name, starts_with })
             }
             ProbeStepBin::FastbootGetvarNotEq { name, not_equals } => {
                 ProbeStep::FastbootGetvarNotEq(FastbootGetvarNotEq { name, not_equals })

--- a/crates/fastboop-schema/src/lib.rs
+++ b/crates/fastboop-schema/src/lib.rs
@@ -55,6 +55,8 @@ pub enum ProbeStep {
     #[serde(untagged)]
     FastbootGetvarEq(FastbootGetvarEq),
     #[serde(untagged)]
+    FastbootGetvarStartsWith(FastbootGetvarStartsWith),
+    #[serde(untagged)]
     FastbootGetvarNotEq(FastbootGetvarNotEq),
     #[serde(untagged)]
     FastbootGetvarExists(FastbootGetvarExists),
@@ -68,6 +70,14 @@ pub struct FastbootGetvarEq {
     #[serde(rename = "fastboot.getvar")]
     pub name: String,
     pub equals: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct FastbootGetvarStartsWith {
+    #[serde(rename = "fastboot.getvar")]
+    pub name: String,
+    pub starts_with: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/devprofiles.d/shift-axolotl.yaml
+++ b/devprofiles.d/shift-axolotl.yaml
@@ -1,0 +1,37 @@
+id: shift-axolotl
+display_name: SHIFT6mq
+devicetree_name: qcom/sdm845-shift-axolotl
+
+match:
+  - fastboot:
+      vid: 0x18d1
+      pid: 0xd00d
+
+# SHIFT6mq shares VID/PID with the OnePlus 6/6T and, for now, only exposes the
+# same SoC-level `product` discriminator. This profile is intentionally kept at
+# that level until we have a SHIFT-specific fastboot var to disambiguate it.
+probe:
+  - fastboot.getvar: product
+    equals: sdm845
+
+boot:
+  fastboot_boot:
+    android_bootimg:
+      header_version: 2
+      page_size: 4096
+      kernel_offset: 0x00008000
+
+      kernel:
+        encoding: image.gz
+
+stage0:
+  inject_mac:
+    bluetooth: qcom,wcn3990-bt
+    wifi: qcom,wcn3990-wifi
+  kernel_modules:
+    - dwc3
+    - dwc3-qcom-legacy
+    - phy-qcom-qusb2
+    - nvmem_qfprom
+    - gcc-sdm845
+    - qnoc-sdm845

--- a/devprofiles.d/shift-axolotl.yaml
+++ b/devprofiles.d/shift-axolotl.yaml
@@ -7,10 +7,9 @@ match:
       vid: 0x18d1
       pid: 0xd00d
 
-# SHIFT6mq shares VID/PID with the OnePlus 6/6T and, for now, only exposes the
-# same SoC-level `product` discriminator. This profile is intentionally kept at
-# that level until we have a SHIFT-specific fastboot var to disambiguate it.
 probe:
+  - fastboot.getvar: serialno
+    starts_with: S6MQ
   - fastboot.getvar: product
     equals: sdm845
 

--- a/docs/dev/DEVICE_PROFILES.md
+++ b/docs/dev/DEVICE_PROFILES.md
@@ -82,6 +82,7 @@ If any required step fails, the profile does not match.
 Current probe primitives in schema are:
 
 - `equals`
+- `starts_with`
 - `not_equals`
 - `exists`
 - `not_exists`
@@ -90,6 +91,9 @@ Practical guidance:
 
 - Put highly discriminating checks early to fail fast.
 - Use multiple checks when one getvar is ambiguous across sibling devices.
+- Use `starts_with` when vendors assign stable serial or SKU prefixes but not a
+  single exact value.
+- `starts_with` is case-sensitive.
 
 ## Boot
 


### PR DESCRIPTION
SHIFT6mq has a similar quirk to enchilada/fajita: they never properly personalized the `product`/`variant` data, so in all cases they read `sdm845`/`SDM UFS`, which forces the user to manually disambiguate in the UI/CLI. Suboptimal.

@chri2's keen eyes observed that his SHIFT6mq's serial number starts with `S6MQ`. He then graciously followed up with SHIFT themselves and got confirmation from their product team that *all* shipped axolotl's will match this serial number scheme.

This new solution is still suboptimal, but less so. I'm not sure if it's possible for any other sdm845 devices out there to randomly have `S6MQ` at the beginning of their serial number. At the very least, most of the devices I've seen so far have lower-case serial numbers. Worst case is somebody plugs in their not-axolotl with a matching serial prefix and they have to disambiguate.

At any rate, once we have #83 in place, we'll probably just opt to punt all ambiguous probes through the secondary u-boot (when possible), since we can then sniff around `/proc/cmdline`/SMEM/whatever to figure out exactly which device we're working with. This PR tides us over until then.