### PR TITLE
Stable MAC addresses

### DIFF
--- a/cli/src/commands/boot.rs
+++ b/cli/src/commands/boot.rs
@@ -369,7 +369,7 @@ async fn run_boot_inner(
             mimic_fastboot: impersonate_fastboot,
             smoo_vendor: detected_device.as_ref().map(|device| device.vid),
             smoo_product: detected_device.as_ref().map(|device| device.pid),
-            smoo_serial: detected_device
+            stage0_serial: detected_device
                 .as_ref()
                 .and_then(|device| device.serial.clone()),
             personalization,

--- a/cli/src/commands/bootprofile.rs
+++ b/cli/src/commands/bootprofile.rs
@@ -405,7 +405,7 @@ rootfs:
     }
 
     #[test]
-    fn parses_stage0_kernel_modules_and_inject_mac_yaml() {
+    fn parses_stage0_kernel_modules_and_device_inject_mac_yaml() {
         let manifest: BootProfileManifest = serde_yaml::from_str(
             r#"
 id: pmos-fajita
@@ -415,28 +415,19 @@ rootfs:
 stage0:
   kernel_modules:
     - dwc3
-  inject_mac:
-    bluetooth: qcom,wcn3990-bt
   devices:
     oneplus-fajita:
       stage0:
         kernel_modules:
           - gcc-sdm845
         inject_mac:
+          bluetooth: qcom,wcn3990-bt
           wifi: qcom,wcn3990-wifi
 "#,
         )
         .expect("parse manifest");
 
         assert_eq!(manifest.stage0.kernel_modules, vec!["dwc3".to_string()]);
-        assert_eq!(
-            manifest
-                .stage0
-                .inject_mac
-                .as_ref()
-                .and_then(|mac| mac.bluetooth.as_deref()),
-            Some("qcom,wcn3990-bt")
-        );
         let device = manifest
             .stage0
             .devices
@@ -451,6 +442,32 @@ stage0:
                 .and_then(|mac| mac.wifi.as_deref()),
             Some("qcom,wcn3990-wifi")
         );
+        assert_eq!(
+            device
+                .stage0
+                .inject_mac
+                .as_ref()
+                .and_then(|mac| mac.bluetooth.as_deref()),
+            Some("qcom,wcn3990-bt")
+        );
+    }
+
+    #[test]
+    fn rejects_global_stage0_inject_mac_yaml() {
+        let err = serde_yaml::from_str::<BootProfileManifest>(
+            r#"
+id: pmos-fajita
+rootfs:
+  erofs:
+    file: ./images/rootfs.ero
+stage0:
+  inject_mac:
+    bluetooth: qcom,wcn3990-bt
+"#,
+        )
+        .expect_err("global inject_mac should be rejected");
+
+        assert!(err.to_string().contains("inject_mac"));
     }
 
     #[test]

--- a/cli/src/commands/stage0.rs
+++ b/cli/src/commands/stage0.rs
@@ -155,7 +155,7 @@ pub async fn run_stage0(args: Stage0Args) -> Result<()> {
             mimic_fastboot: args.impersonate_fastboot,
             smoo_vendor: None,
             smoo_product: None,
-            smoo_serial: None,
+            stage0_serial: None,
             personalization: None,
         };
 

--- a/crates/fastboop-core/src/bootprofile.rs
+++ b/crates/fastboop-core/src/bootprofile.rs
@@ -116,14 +116,14 @@ pub fn resolve_effective_boot_profile_stage0(
     let mut dt_overlays = profile.dt_overlays.clone();
     let mut kernel_modules = profile.stage0.kernel_modules.clone();
     let mut extra_cmdline = profile.extra_cmdline.clone();
-    let mut inject_mac = profile.stage0.inject_mac.clone();
+    let mut inject_mac = None;
 
     if let Some(device) = profile.stage0.devices.get(device_profile_id) {
         dt_overlays.extend(device.dt_overlays.iter().cloned());
         kernel_modules.extend(device.stage0.kernel_modules.iter().cloned());
         extra_cmdline =
             join_cmdline_parts(extra_cmdline.as_deref(), device.extra_cmdline.as_deref());
-        inject_mac = merge_inject_mac(inject_mac.as_ref(), device.stage0.inject_mac.as_ref());
+        inject_mac = device.stage0.inject_mac.clone();
     }
 
     EffectiveBootProfileStage0 {
@@ -132,22 +132,6 @@ pub fn resolve_effective_boot_profile_stage0(
         kernel_modules,
         inject_mac,
     }
-}
-
-fn merge_inject_mac(
-    primary: Option<&InjectMac>,
-    secondary: Option<&InjectMac>,
-) -> Option<InjectMac> {
-    let wifi = secondary
-        .and_then(|mac| mac.wifi.clone())
-        .or_else(|| primary.and_then(|mac| mac.wifi.clone()));
-    let bluetooth = secondary
-        .and_then(|mac| mac.bluetooth.clone())
-        .or_else(|| primary.and_then(|mac| mac.bluetooth.clone()));
-    if wifi.is_none() && bluetooth.is_none() {
-        return None;
-    }
-    Some(InjectMac { wifi, bluetooth })
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/fastboop-core/tests/bootprofile.rs
+++ b/crates/fastboop-core/tests/bootprofile.rs
@@ -406,7 +406,7 @@ fn sample_profile() -> BootProfile {
                 kernel_modules: vec!["qcom-foo".to_string()],
                 inject_mac: Some(InjectMac {
                     wifi: Some("qcom,wcn3990-wifi-device".to_string()),
-                    bluetooth: None,
+                    bluetooth: Some("qcom,wcn3990-bt".to_string()),
                 }),
             },
         },
@@ -430,10 +430,6 @@ fn sample_profile() -> BootProfile {
         extra_cmdline: Some("selinux=0".to_string()),
         stage0: BootProfileStage0 {
             kernel_modules: vec!["erofs".to_string()],
-            inject_mac: Some(InjectMac {
-                wifi: Some("qcom,wcn3990-wifi".to_string()),
-                bluetooth: Some("qcom,wcn3990-bt".to_string()),
-            }),
             devices,
         },
     }

--- a/crates/fastboop-schema/src/bin.rs
+++ b/crates/fastboop-schema/src/bin.rs
@@ -69,7 +69,6 @@ pub enum BootProfileRootfsFilesystemBin {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BootProfileStage0Bin {
     pub kernel_modules: Vec<String>,
-    pub inject_mac: Option<InjectMacBin>,
     pub devices: BTreeMap<String, BootProfileDeviceBin>,
 }
 
@@ -341,7 +340,6 @@ impl From<BootProfileStage0> for BootProfileStage0Bin {
     fn from(stage0: BootProfileStage0) -> Self {
         Self {
             kernel_modules: stage0.kernel_modules,
-            inject_mac: stage0.inject_mac.map(InjectMacBin::from),
             devices: stage0
                 .devices
                 .into_iter()
@@ -355,7 +353,6 @@ impl From<BootProfileStage0Bin> for BootProfileStage0 {
     fn from(stage0: BootProfileStage0Bin) -> Self {
         Self {
             kernel_modules: stage0.kernel_modules,
-            inject_mac: stage0.inject_mac.map(InjectMac::from),
             devices: stage0
                 .devices
                 .into_iter()

--- a/crates/fastboop-schema/src/lib.rs
+++ b/crates/fastboop-schema/src/lib.rs
@@ -297,7 +297,6 @@ impl BootProfileManifest {
             extra_cmdline: self.extra_cmdline.clone(),
             stage0: BootProfileStage0 {
                 kernel_modules: self.stage0.kernel_modules.clone(),
-                inject_mac: self.stage0.inject_mac.clone(),
                 devices,
             },
         })
@@ -310,15 +309,13 @@ impl BootProfileManifest {
 pub struct BootProfileManifestStage0 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub kernel_modules: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub inject_mac: Option<InjectMac>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub devices: BTreeMap<String, BootProfileManifestDevice>,
 }
 
 impl BootProfileManifestStage0 {
     pub fn is_empty(&self) -> bool {
-        self.kernel_modules.is_empty() && self.inject_mac.is_none() && self.devices.is_empty()
+        self.kernel_modules.is_empty() && self.devices.is_empty()
     }
 }
 
@@ -413,7 +410,6 @@ impl BootProfile {
             extra_cmdline: self.extra_cmdline.clone(),
             stage0: BootProfileManifestStage0 {
                 kernel_modules: self.stage0.kernel_modules.clone(),
-                inject_mac: self.stage0.inject_mac.clone(),
                 devices,
             },
         })
@@ -426,15 +422,13 @@ impl BootProfile {
 pub struct BootProfileStage0 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub kernel_modules: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub inject_mac: Option<InjectMac>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub devices: BTreeMap<String, BootProfileDevice>,
 }
 
 impl BootProfileStage0 {
     pub fn is_empty(&self) -> bool {
-        self.kernel_modules.is_empty() && self.inject_mac.is_none() && self.devices.is_empty()
+        self.kernel_modules.is_empty() && self.devices.is_empty()
     }
 }
 

--- a/crates/fastboop-stage0-generator/src/lib.rs
+++ b/crates/fastboop-stage0-generator/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Stage0Options {
     pub mimic_fastboot: bool,
     pub smoo_vendor: Option<u16>,
     pub smoo_product: Option<u16>,
-    pub smoo_serial: Option<String>,
+    pub stage0_serial: Option<String>,
     pub personalization: Option<Personalization>,
 }
 
@@ -113,6 +113,14 @@ pub async fn build_stage0<P: Filesystem>(
 ) -> Result<Stage0Build, Stage0Error> {
     let init_path = INIT_BIN_PATH.to_string();
     let needs_modules = true;
+    let (extra_stage0_settings, extra_cmdline_passthrough): (
+        BTreeMap<String, String>,
+        Vec<String>,
+    ) = extra_cmdline
+        .map(str::trim)
+        .filter(|extra| !extra.is_empty())
+        .map(split_extra_cmdline)
+        .unwrap_or_default();
     tracing::debug!(
         needs_modules,
         switchroot_fs = opts.switchroot_fs.as_stage0_value(),
@@ -209,11 +217,15 @@ pub async fn build_stage0<P: Filesystem>(
 
     let kernel_image = kernel::normalize_kernel(profile, &kernel_image)?;
     let dtb_bytes = apply_dtbo_overlays(&dtb_bytes, &opts.dtbo_overlays)?;
-    let mac_seed = opts
-        .smoo_serial
-        .as_deref()
-        .map(str::trim)
-        .filter(|serial| !serial.is_empty())
+    let mac_seed = extra_stage0_settings
+        .get("stage0.serial")
+        .map(String::as_str)
+        .or_else(|| {
+            opts.stage0_serial
+                .as_deref()
+                .map(str::trim)
+                .filter(|serial| !serial.is_empty())
+        })
         .unwrap_or("0");
     let dtb_bytes = apply_mac_injection(&dtb_bytes, &opts.inject_mac, mac_seed)?;
     let _dtb = Fdt::new(&dtb_bytes).map_err(|_| Stage0Error::ParseError("dtb"))?;
@@ -307,10 +319,10 @@ pub async fn build_stage0<P: Filesystem>(
     if let Some(product) = opts.smoo_product {
         stage0_settings.insert("smoo.product".to_string(), format!("0x{product:04x}"));
     }
-    if let Some(serial) = opts.smoo_serial.as_ref() {
+    if let Some(serial) = opts.stage0_serial.as_ref() {
         let serial = serial.trim();
         if !serial.is_empty() {
-            stage0_settings.insert("smoo.serial".to_string(), serial.to_string());
+            stage0_settings.insert("stage0.serial".to_string(), serial.to_string());
         }
     }
     if let Some(personalization) = &opts.personalization {
@@ -318,16 +330,10 @@ pub async fn build_stage0<P: Filesystem>(
             stage0_settings.insert(key, value);
         }
     }
-    if let Some(extra) = extra_cmdline {
-        let extra = extra.trim();
-        if !extra.is_empty() {
-            let (from_extra, passthrough) = split_extra_cmdline(extra);
-            for (key, value) in from_extra {
-                stage0_settings.insert(key, value);
-            }
-            cmdline_parts.extend(passthrough);
-        }
+    for (key, value) in extra_stage0_settings {
+        stage0_settings.insert(key, value);
     }
+    cmdline_parts.extend(extra_cmdline_passthrough);
     stage0_settings.insert(
         "stage0.rootfs".to_string(),
         opts.switchroot_fs.as_stage0_value().to_string(),
@@ -432,6 +438,7 @@ fn is_stage0_config_key(key: &str) -> bool {
         key,
         "ostree"
             | "stage0.fb"
+            | "stage0.serial"
             | "stage0.yeetfstab"
             | "stage0.rootfs"
             | "smoo.acm"
@@ -445,7 +452,6 @@ fn is_stage0_config_key(key: &str) -> bool {
             | "smoo.vendor_id"
             | "smoo.product"
             | "smoo.product_id"
-            | "smoo.serial"
             | "smoo.mimic_fastboot"
             | "smoo.log"
             | "firstboot.locale"
@@ -1286,11 +1292,15 @@ mod tests {
     #[test]
     fn split_extra_cmdline_extracts_stage0_tokens() {
         let (stage0_settings, passthrough) = split_extra_cmdline(
-            "quiet smoo.log=trace smoo.acm stage0.yeetfstab=0 ostree=/ostree/boot.1/fedora/deadbeef/0",
+            "quiet smoo.log=trace smoo.acm stage0.serial=abc123 stage0.yeetfstab=0 ostree=/ostree/boot.1/fedora/deadbeef/0",
         );
 
         assert_eq!(stage0_settings.get("smoo.log"), Some(&"trace".to_string()));
         assert_eq!(stage0_settings.get("smoo.acm"), Some(&"1".to_string()));
+        assert_eq!(
+            stage0_settings.get("stage0.serial"),
+            Some(&"abc123".to_string())
+        );
         assert_eq!(
             stage0_settings.get("stage0.yeetfstab"),
             Some(&"0".to_string())

--- a/crates/fastboop-stage0-generator/src/lib.rs
+++ b/crates/fastboop-stage0-generator/src/lib.rs
@@ -209,7 +209,13 @@ pub async fn build_stage0<P: Filesystem>(
 
     let kernel_image = kernel::normalize_kernel(profile, &kernel_image)?;
     let dtb_bytes = apply_dtbo_overlays(&dtb_bytes, &opts.dtbo_overlays)?;
-    let dtb_bytes = apply_mac_injection(&dtb_bytes, &opts.inject_mac)?;
+    let mac_seed = opts
+        .smoo_serial
+        .as_deref()
+        .map(str::trim)
+        .filter(|serial| !serial.is_empty())
+        .unwrap_or("0");
+    let dtb_bytes = apply_mac_injection(&dtb_bytes, &opts.inject_mac, mac_seed)?;
     let _dtb = Fdt::new(&dtb_bytes).map_err(|_| Stage0Error::ParseError("dtb"))?;
 
     let required_modules = collect_required_modules(opts, &modules_dep);
@@ -1116,7 +1122,11 @@ fn parse_fixup_offsets(bytes: &[u8]) -> Result<Vec<u32>, Stage0Error> {
     Ok(out)
 }
 
-fn apply_mac_injection(dtb: &[u8], inject: &Option<InjectMac>) -> Result<Vec<u8>, Stage0Error> {
+fn apply_mac_injection(
+    dtb: &[u8],
+    inject: &Option<InjectMac>,
+    seed: &str,
+) -> Result<Vec<u8>, Stage0Error> {
     let Some(inject) = inject else {
         return Ok(dtb.to_vec());
     };
@@ -1126,8 +1136,6 @@ fn apply_mac_injection(dtb: &[u8], inject: &Option<InjectMac>) -> Result<Vec<u8>
 
     let fdt = Fdt::new(dtb).map_err(|_| Stage0Error::ParseError("dtb"))?;
     let mut tree = DeviceTree::from_fdt(&fdt).map_err(|_| Stage0Error::ParseError("dtb"))?;
-    let seed = 0u64;
-
     if let Some(compat) = inject.wifi.as_deref() {
         let mac = mac_from_seed(seed, "wifi", compat);
         let node = find_node_by_compatible_mut(&mut tree.root, compat).ok_or_else(|| {
@@ -1151,8 +1159,8 @@ fn apply_mac_injection(dtb: &[u8], inject: &Option<InjectMac>) -> Result<Vec<u8>
     Ok(tree.to_dtb())
 }
 
-fn mac_from_seed(seed: u64, kind: &str, compat: &str) -> [u8; 6] {
-    let mut hash = fnv1a64(seed.to_le_bytes().iter().copied());
+fn mac_from_seed(seed: &str, kind: &str, compat: &str) -> [u8; 6] {
+    let mut hash = fnv1a64(seed.as_bytes().iter().copied());
     hash = fnv1a64_with_seed(hash, kind.as_bytes().iter().copied());
     hash = fnv1a64_with_seed(hash, compat.as_bytes().iter().copied());
     let mut mac = [0u8; 6];
@@ -1233,9 +1241,16 @@ mod tests {
 
     #[test]
     fn mac_from_seed_sets_local_admin() {
-        let mac = mac_from_seed(0, "wifi", "qcom,wcn3990-wifi");
+        let mac = mac_from_seed("serial-1", "wifi", "qcom,wcn3990-wifi");
         assert_eq!(mac[0] & 0x01, 0);
         assert_eq!(mac[0] & 0x02, 0x02);
+    }
+
+    #[test]
+    fn mac_from_seed_uses_serial_seed() {
+        let first = mac_from_seed("serial-1", "wifi", "qcom,wcn3990-wifi");
+        let second = mac_from_seed("serial-2", "wifi", "qcom,wcn3990-wifi");
+        assert_ne!(first, second);
     }
 
     #[test]
@@ -1253,17 +1268,17 @@ mod tests {
             wifi: Some("qcom,wcn3990-wifi".to_string()),
             bluetooth: Some("qcom,wcn3990-bt".to_string()),
         };
-        let out = apply_mac_injection(&dtb, &Some(inject)).unwrap();
+        let out = apply_mac_injection(&dtb, &Some(inject), "serial-1").unwrap();
         let fdt = Fdt::new(&out).unwrap();
 
         let wifi_node = fdt.find_node(wifi_path).unwrap();
         let wifi_prop = wifi_node.property("local-mac-address").unwrap();
-        let expected_wifi = mac_from_seed(0, "wifi", "qcom,wcn3990-wifi");
+        let expected_wifi = mac_from_seed("serial-1", "wifi", "qcom,wcn3990-wifi");
         assert_eq!(wifi_prop.value(), expected_wifi);
 
         let bt_node = fdt.find_node(bt_path).unwrap();
         let bt_prop = bt_node.property("local-bd-address").unwrap();
-        let mut expected_bt = mac_from_seed(0, "bluetooth", "qcom,wcn3990-bt");
+        let mut expected_bt = mac_from_seed("serial-1", "bluetooth", "qcom,wcn3990-bt");
         expected_bt.reverse();
         assert_eq!(bt_prop.value(), expected_bt);
     }

--- a/docs/dev/BOOT_PROFILES.md
+++ b/docs/dev/BOOT_PROFILES.md
@@ -84,9 +84,6 @@ stage0:
   kernel_modules:
     - dwc3
     - dwc3-qcom
-  inject_mac:
-    bluetooth: qcom,wcn3990-bt
-    wifi: qcom,wcn3990-wifi
   devices:
     oneplus-fajita:
       dt_overlays:
@@ -105,13 +102,17 @@ stage0:
       stage0:
         kernel_modules:
           - gcc-sdm845
+        inject_mac:
+          bluetooth: qcom,wcn3990-bt
+          wifi: qcom,wcn3990-wifi
 ```
 
 ## Validation Highlights
 
 - `rootfs` schema supports `erofs`, `ext4`, and `fat`.
 - Stage0 lower-root currently accepts `erofs` and `ext4`; use `fat` for kernel/dtbs source pipelines.
-- `stage0.kernel_modules` and `stage0.inject_mac` may be global or scoped under `stage0.devices.<device-profile-id>.stage0`; device-specific values append modules and override MAC injection fields.
+- `stage0.kernel_modules` may be global or scoped under `stage0.devices.<device-profile-id>.stage0`; device-specific modules append to global modules.
+- `stage0.devices.<device-profile-id>.stage0.inject_mac` is device-scoped only. It identifies target nodes by `compatible` string for the selected device DTB.
 - Artifact pipeline validation/limits come from `gibblox-pipeline` (`MAX_PIPELINE_DEPTH=16`).
 - Terminal stages (`http`, `casync`, `file`) must include `content` metadata (`digest`, `size_bytes`). `bootprofile create` auto-populates `content` for bare local `file` sources by hashing the referenced path, so hand-authored manifests pointing at `pmbootstrap export` output (or any other local artifact) can omit it.
 - Wrapper stages (`xz`, `android_sparseimg`, `mbr`, `gpt`) may include optional `content` metadata.

--- a/docs/dev/STAGE0.md
+++ b/docs/dev/STAGE0.md
@@ -20,7 +20,7 @@ Stage0 PID1 (`fastboop-stage0`) does this in order:
 3. configure configfs/FunctionFS and spawn embedded `smoo-gadget-app`
 4. wait for exported block device (`/dev/ublkb0`)
 5. mount lower root (`erofs` or `ext4`) + tmpfs upper overlay
-6. seed an ephemeral `/etc/machine-id` for this boot
+6. seed `/etc/machine-id` from `stage0.serial`, or ephemerally when no serial seed is available
 7. switch root and `exec` init (`/lib/systemd/systemd`, `/usr/lib/systemd/systemd`, or `/sbin/init`)
 
 If gadget startup or handoff fails, stage0 fails loudly.
@@ -39,6 +39,7 @@ Stage0 reads runtime settings from files under `/etc/stage0` in the generated in
 Notable keys include:
 
 - `stage0.rootfs` (required)
+- `stage0.serial` (optional; generic serial seed used for deterministic machine identity and gadget USB serial)
 - `stage0.yeetfstab` (default `1`; set `0` to preserve `/etc/fstab`)
 - `ostree`
 - `smoo.acm`, `smoo.queue_count`, `smoo.queue_depth`, `smoo.max_io_bytes`

--- a/docs/dev/attic/DEVICE_PROFILES-v0.md
+++ b/docs/dev/attic/DEVICE_PROFILES-v0.md
@@ -121,12 +121,12 @@ Those belong elsewhere.
 
 ## Stage0 MAC injection
 
-Stage0 MAC injection now belongs to Boot Profiles. Optional `stage0.inject_mac` entries there identify target nodes by `compatible` string and inject deterministic addresses into the DTB used by stage0:
+Stage0 MAC injection now belongs to Boot Profiles. Optional `stage0.devices.<device-profile-id>.stage0.inject_mac` entries identify target nodes by `compatible` string and inject deterministic addresses into the DTB used by stage0:
 
 - `wifi` writes `local-mac-address` using MSB order
 - `bluetooth` writes `local-bd-address` using LSB order
 
-Both fields are optional; omit BootProfile `stage0.inject_mac` entirely if no injection is needed.
+Both fields are optional; omit the per-device BootProfile `stage0.devices.<device-profile-id>.stage0.inject_mac` entirely if no injection is needed.
 
 ---
 

--- a/packages/desktop/src/views/device_boot.rs
+++ b/packages/desktop/src/views/device_boot.rs
@@ -132,7 +132,7 @@ pub async fn boot_selected_device(
         mimic_fastboot: true,
         smoo_vendor: Some(session.device.vid),
         smoo_product: Some(session.device.pid),
-        smoo_serial: session.device.serial.clone(),
+        stage0_serial: session.device.serial.clone(),
         personalization: Some(personalization_from_host()),
     };
     let (build, runtime) = build_stage0_artifacts(

--- a/packages/web/src/views/device_boot.rs
+++ b/packages/web/src/views/device_boot.rs
@@ -316,7 +316,7 @@ pub async fn boot_selected_device(
         mimic_fastboot: true,
         smoo_vendor: Some(session.device.vid),
         smoo_product: Some(session.device.pid),
-        smoo_serial: webusb_serial_number(&session.device.handle),
+        stage0_serial: webusb_serial_number(&session.device.handle),
         personalization: Some(personalization_from_browser()),
     };
     let profile_id = session.device.profile.id.clone();

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -64,6 +64,9 @@ const STAGE0_ROLE_KMSG_CHILD: &str = "kmsg-child";
 const STAGE0_ROLE_FRAMEBUFFER_CHILD: &str = "framebuffer-child";
 const STAGE0_CONFIG_DIR: &str = "/etc/stage0";
 const STAGE0_CREDSTORE_DIR: &str = "/run/credstore";
+const MACHINE_ID_SERIAL_DOMAIN: &str = "fastboop-stage0-machine-id-v1";
+const FNV1A64_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV1A64_PRIME: u64 = 0x100000001b3;
 
 static STAGE0_CONFIG: OnceLock<HashMap<String, String>> = OnceLock::new();
 
@@ -531,7 +534,7 @@ fn run_pid1(args: &Args, cleaned_args: &[OsString]) -> Result<()> {
     }
     ensure_serial_getty().ok();
     if let Err(err) = stage_machine_id() {
-        warn!(error = ?err, "pid1: failed to stage ephemeral /etc/machine-id");
+        warn!(error = ?err, "pid1: failed to stage /etc/machine-id");
     }
     stage_firstboot_credentials().context("stage firstboot credentials")?;
 
@@ -573,6 +576,12 @@ fn stage0_yeet_fstab_enabled() -> bool {
 
 fn cmdline_value(key: &str) -> Option<String> {
     stage0_config().get(key).cloned()
+}
+
+fn stage0_serial() -> Option<String> {
+    cmdline_value("stage0.serial")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn ensure_serial_getty() -> Result<()> {
@@ -731,17 +740,46 @@ fn stage_machine_id() -> Result<()> {
     let mut contents = machine_id.into_bytes();
     contents.push(b'\n');
     std::fs::write(path, contents).context("write /etc/machine-id")?;
-    info!("pid1: staged ephemeral /etc/machine-id");
+    info!("pid1: staged /etc/machine-id");
     Ok(())
 }
 
 fn generate_machine_id() -> Result<String> {
+    if let Some(serial) = stage0_serial() {
+        return Ok(machine_id_from_serial(&serial));
+    }
+
     let mut bytes = [0u8; 16];
     let mut urandom = File::open("/dev/urandom").context("open /dev/urandom")?;
     urandom
         .read_exact(&mut bytes)
         .context("read /dev/urandom")?;
     Ok(machine_id_from_bytes(bytes))
+}
+
+fn machine_id_from_serial(serial: &str) -> String {
+    let mut bytes = [0u8; 16];
+    bytes[..8].copy_from_slice(&machine_id_seed_hash(serial, 0).to_be_bytes());
+    bytes[8..].copy_from_slice(&machine_id_seed_hash(serial, 1).to_be_bytes());
+    machine_id_from_bytes(bytes)
+}
+
+fn machine_id_seed_hash(serial: &str, round: u8) -> u64 {
+    let mut hash = FNV1A64_OFFSET;
+    hash = fnv1a64_with_seed(hash, MACHINE_ID_SERIAL_DOMAIN.as_bytes().iter().copied());
+    hash = fnv1a64_with_seed(hash, [0]);
+    hash = fnv1a64_with_seed(hash, serial.as_bytes().iter().copied());
+    hash = fnv1a64_with_seed(hash, [0]);
+    fnv1a64_with_seed(hash, [round])
+}
+
+fn fnv1a64_with_seed<I: IntoIterator<Item = u8>>(seed: u64, bytes: I) -> u64 {
+    let mut hash = seed;
+    for byte in bytes {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(FNV1A64_PRIME);
+    }
+    hash
 }
 
 fn machine_id_from_bytes(mut bytes: [u8; 16]) -> String {
@@ -1203,13 +1241,10 @@ fn spawn_gadget_child(
         child_args.push(OsStr::new(&format!("0x{product_id:04x}")).to_os_string());
         info!("pid1: using product id 0x{product_id:04x} from stage0 config");
     }
-    if let Some(serial) = cmdline_value("smoo.serial") {
-        let serial = serial.trim();
-        if !serial.is_empty() {
-            child_args.push(OsStr::new("--serial").to_os_string());
-            child_args.push(OsStr::new(serial).to_os_string());
-            info!("pid1: using USB serial from stage0 config");
-        }
+    if let Some(serial) = stage0_serial() {
+        child_args.push(OsStr::new("--serial").to_os_string());
+        child_args.push(OsStr::new(&serial).to_os_string());
+        info!("pid1: using USB serial from stage0 config");
     }
     if cmdline_bool("smoo.mimic_fastboot") {
         child_args.push(OsStr::new("--mimic-fastboot").to_os_string());
@@ -1696,10 +1731,7 @@ fn gadget_usb_identity(args: &Args) -> (u16, u16, String) {
     let product_id = cmdline_u16_flexible("smoo.product")
         .or_else(|| cmdline_u16_flexible("smoo.product_id"))
         .unwrap_or(args.product_id);
-    let serial = cmdline_value("smoo.serial")
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| args.serial.clone());
+    let serial = stage0_serial().unwrap_or_else(|| args.serial.clone());
     (vendor_id, product_id, serial)
 }
 
@@ -1866,6 +1898,24 @@ mod tests {
     fn machine_id_from_bytes_rejects_all_zero_identity() {
         let id = machine_id_from_bytes([0; 16]);
         assert_eq!(id, "01000000000000000000000000000000");
+    }
+
+    #[test]
+    fn machine_id_from_serial_is_stable_lowercase_hex() {
+        let id = machine_id_from_serial("serial-1");
+
+        assert_eq!(id, machine_id_from_serial("serial-1"));
+        assert_eq!(id.len(), 32);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(id, id.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn machine_id_from_serial_uses_serial_seed() {
+        let first = machine_id_from_serial("serial-1");
+        let second = machine_id_from_serial("serial-2");
+
+        assert_ne!(first, second);
     }
 
     #[test]


### PR DESCRIPTION
Most of the infra was already in place, it just wasn't fully wired up. We now seed the injected `local-mac-address`/`local-bd-address` from the device's serial.

We also extend this concept to the generated `/etc/machine-id`, since Fedora (and likely others) have configured NetworkManager with `wifi.cloned-mac-address=stable-ssid`: https://src.fedoraproject.org/rpms/NetworkManager/blob/rawhide/f/22-wifi-mac-addr.conf. Apparently (idk I just took the clanker on its word here) NetworkManager uses both `/var/lib/NetworkManager/secret_key` as well as `/etc/machine-id` to seed these per-SSID MAC addresses.

I tested this with rokkitpokkit and confirm that subsequent boots are getting a consistent MAC address.